### PR TITLE
Bytecode Storage

### DIFF
--- a/src/onlydust/imhotep/evm.cairo
+++ b/src/onlydust/imhotep/evm.cairo
@@ -1,12 +1,7 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-
-// Since 32 bytes cannot be stored into a single field element, we sepeate the higher and lower 16 bytes.
-struct Bytes32 {
-    low: felt,
-    high: felt,
-}
+from starkware.cairo.common.uint256 import Uint256 as Bytes32
 
 @storage_var
 func storage(key: Bytes32) -> (value: Bytes32) {

--- a/src/onlydust/imhotep/evm.cairo
+++ b/src/onlydust/imhotep/evm.cairo
@@ -2,9 +2,60 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.uint256 import Uint256 as Bytes32
+from starkware.cairo.common.alloc import alloc
+
+@storage_var
+func len_contr_bytecode() -> (len: felt) {
+}
+
+@storage_var
+func contr_bytecode(index: felt) -> (res: felt) {
+}
 
 @storage_var
 func storage(key: Bytes32) -> (value: Bytes32) {
+}
+
+@constructor
+func constructor{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(contr_bytecode_len: felt, contr_bytecode: felt*) {
+    len_contr_bytecode.write(contr_bytecode_len);
+    process_array(contr_bytecode_len, contr_bytecode);
+
+    return ();
+}
+
+func process_array{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(code_len: felt, code: felt*) {
+    if (code_len == 0) { 
+        return (); 
+    }
+
+    contr_bytecode.write(code_len - 1, code[code_len - 1]); 
+    process_array(code_len - 1, code);
+    return ();
+}
+
+func build_bytecode{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(code_len: felt, code: felt*) -> (code_len: felt, code: felt*) {
+    if (code_len == 0) {
+        return (code_len=0, code=code);
+    }
+
+    let (res) = contr_bytecode.read(code_len - 1);
+    assert [code + code_len - 1] = res;
+    let (code_len, code) = build_bytecode(code_len - 1, code);
+    return (code_len=code_len, code=code);
+}
+
+@view
+func get_bytecode{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}() -> (code_len: felt, code: felt*) {
+    alloc_locals;
+    let (len) = len_contr_bytecode.read();
+    local len = len;
+
+    let (bytecode: felt*) = alloc();
+    build_bytecode(len, bytecode);
+
+
+    return (code_len=len, code=bytecode);
 }
 
 func _sstore{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(key: Bytes32, value: Bytes32) {

--- a/src/onlydust/imhotep/tests/test_bytecode.cairo
+++ b/src/onlydust/imhotep/tests/test_bytecode.cairo
@@ -1,0 +1,35 @@
+%lang starknet
+from starkware.cairo.common.cairo_builtins import  HashBuiltin
+from starkware.cairo.common.uint256 import Uint256 as Uint256
+
+@contract_interface
+namespace EvmBytecode {
+
+    func get_bytecode() -> (code_len: felt, code: felt*){
+    }
+    
+}
+
+@external
+func __setup__() {
+
+    %{ context.contract_address = deploy_contract("./src/onlydust/imhotep/evm.cairo", { "contr_bytecode": [1, 2, 3] }).contract_address %}
+    return ();
+}
+
+@external
+func test_bytecode{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}() {
+    alloc_locals;
+
+    local addr;
+    %{ ids.addr = context.contract_address %}
+
+    let (code_len, code) =  EvmBytecode.get_bytecode(contract_address=addr);
+
+    assert code_len = 3;
+
+    assert [code] = 1;
+    assert [code + 1] = 2;
+    assert [code + 2] = 3;
+    return ();
+}

--- a/src/onlydust/imhotep/tests/test_bytecode.cairo
+++ b/src/onlydust/imhotep/tests/test_bytecode.cairo
@@ -13,7 +13,7 @@ namespace EvmBytecode {
 @external
 func __setup__() {
 
-    %{ context.contract_address = deploy_contract("./src/onlydust/imhotep/evm.cairo", { "contr_bytecode": [1, 2, 3] }).contract_address %}
+    %{ context.contract_address = deploy_contract("./src/onlydust/imhotep/evm.cairo", { "_bytecode": [1, 2, 3] }).contract_address %}
     return ();
 }
 

--- a/src/onlydust/imhotep/tests/test_storage.cairo
+++ b/src/onlydust/imhotep/tests/test_storage.cairo
@@ -1,7 +1,8 @@
 %lang starknet
 from starkware.cairo.common.cairo_builtins import  HashBuiltin
+from starkware.cairo.common.uint256 import Uint256 as Bytes32
 
-from src.onlydust.imhotep.evm import _sstore, _sload, Bytes32
+from src.onlydust.imhotep.evm import _sstore, _sload
 
 @external
 func test_storage{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}() {

--- a/src/onlydust/imhotep/tests/test_storage.cairo
+++ b/src/onlydust/imhotep/tests/test_storage.cairo
@@ -1,20 +1,20 @@
 %lang starknet
 from starkware.cairo.common.cairo_builtins import  HashBuiltin
-from starkware.cairo.common.uint256 import Uint256 as Bytes32
+from starkware.cairo.common.uint256 import Uint256 as Uint256
 
 from src.onlydust.imhotep.evm import _sstore, _sload
 
 @external
 func test_storage{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}() {
     alloc_locals;
-    local key: Bytes32;
-    local value: Bytes32;
+    local key: Uint256;
+    local value: Uint256;
 
-    assert key = Bytes32(low=30, high=0);
-    assert value = Bytes32(low=10234, high=0);
+    assert key = Uint256(low=30, high=0);
+    assert value = Uint256(low=10234, high=0);
 
     _sstore(key, value);
-    let stored_value : Bytes32 = _sload(key);
+    let stored_value : Uint256 = _sload(key);
 
     assert stored_value = value;
     return ();

--- a/src/onlydust/imhotep/tests/test_storage.cairo
+++ b/src/onlydust/imhotep/tests/test_storage.cairo
@@ -1,20 +1,20 @@
 %lang starknet
 from starkware.cairo.common.cairo_builtins import  HashBuiltin
-from starkware.cairo.common.uint256 import Uint256 as Uint256
+from starkware.cairo.common.uint256 import Uint256 as Bytes32
 
 from src.onlydust.imhotep.evm import _sstore, _sload
 
 @external
 func test_storage{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}() {
     alloc_locals;
-    local key: Uint256;
-    local value: Uint256;
+    local key: Bytes32;
+    local value: Bytes32;
 
-    assert key = Uint256(low=30, high=0);
-    assert value = Uint256(low=10234, high=0);
+    assert key = Bytes32(low=30, high=0);
+    assert value = Bytes32(low=10234, high=0);
 
     _sstore(key, value);
-    let stored_value : Uint256 = _sload(key);
+    let stored_value : Bytes32 = _sload(key);
 
     assert stored_value = value;
     return ();


### PR DESCRIPTION
## Overview
Since Cairo does not natively support arbitrary bytecode storage, the contract bytecode will need to be stored in a `felt*`. However, this isn't that big of a deal since `bytes memory` in solidity under the hood happens to be `bytes` array. But also, Cairo also does not support storing `felt*` in their `@storage_var`s. So I opted to emulate the pattern Openzepplin used for their `ERC721Enumerable`:
```
@storage_var
func ERC721Enumerable_all_tokens_len() -> (total_supply: Uint256) {
}

@storage_var
func ERC721Enumerable_all_tokens(index: Uint256) -> (token_id: Uint256) {
}
```

We store one `@storage_var` to represent the length of the bytes array and another one to represent a map from the index to the value. After that, there is one function called in the constructor to store the bytes array and another function to built the storage variables into a `felt*` which can be used by the `@view` function. 

NOTE: For the future, one thing that will have to be standardized is how many bytes/opcodes will be stored in one element of the `felt*`.

Closes #19 